### PR TITLE
Move maven dependencies to provides scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,7 @@
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
 			<version>${version.maven-plugin-api}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
@@ -152,6 +153,7 @@
 			<groupId>org.codehaus.plexus</groupId>
 			<artifactId>plexus-compiler-api</artifactId>
 			<version>${version.plexus-compiler-api}</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
The maven distribution itself already contains them, no need to force them onto the user.

fixes #37 