### PR TITLE
fix testThreadNumbering

### DIFF
--- a/src/main/java/com/pro_crafting/tools/jasperreport/JasperReporterThreadFactory.java
+++ b/src/main/java/com/pro_crafting/tools/jasperreport/JasperReporterThreadFactory.java
@@ -8,11 +8,13 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class JasperReporterThreadFactory implements ThreadFactory {
 
+    static final String THREAD_PREFIX = "jasper-compiler-";
+
     private static final AtomicInteger THREAD_COUNTER = new AtomicInteger();
 
     @Override
     public Thread newThread(Runnable r) {
-        Thread thread = new Thread(r, "jasper-compiler-" + THREAD_COUNTER.incrementAndGet());
+        Thread thread = new Thread(r, THREAD_PREFIX + THREAD_COUNTER.incrementAndGet());
         thread.setDaemon(true);
         return thread;
     }


### PR DESCRIPTION
This test did not fail if the thread numbers did not match the expected. Now just test if the pattern matches, and the threads are numbered sequentially.