### PR TITLE
mark jasper mojo as threadsafe

### DIFF
--- a/src/main/java/com/pro_crafting/tools/jasperreport/JasperMojo.java
+++ b/src/main/java/com/pro_crafting/tools/jasperreport/JasperMojo.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  * so, it keeps the folder structure intact.
  */
 @Mojo(defaultPhase = LifecyclePhase.PROCESS_RESOURCES, name = "jasper", requiresDependencyResolution =
-		ResolutionScope.COMPILE)
+		ResolutionScope.COMPILE, threadSafe = true)
 public class JasperMojo extends AbstractMojo {
 	private static final Logger LOGGER = LoggerFactory.getLogger(JasperMojo.class);
 


### PR DESCRIPTION
This prevents a warning when running with e.g. -T 1C flag. The plugin and jasper itself should be threadsafe enough, since we by default run 4 threads anyway..