### PR TITLE
Fix #104: Eliminate some build warnings and fixed some typos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,10 +210,10 @@
 			<plugin>
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<configuration>
-					<systemProperties>
+					<systemPropertyVariables>
 						<maven.version>${maven.version}</maven.version>
 						<maven.home>${maven.home}</maven.home>
-					</systemProperties>
+					</systemPropertyVariables>
 					<properties>
 						<configurationParameters>
 							junit.jupiter.execution.parallel.enabled=true

--- a/src/main/java/com/pro_crafting/tools/jasperreport/JasperMojoConfiguration.java
+++ b/src/main/java/com/pro_crafting/tools/jasperreport/JasperMojoConfiguration.java
@@ -6,7 +6,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Map;
 
-public class JasperMojoConfiguration {
+class JasperMojoConfiguration {
     public String compiler;
 
     public File outputDirectory;

--- a/src/main/java/com/pro_crafting/tools/jasperreport/JasperReportCompiler.java
+++ b/src/main/java/com/pro_crafting/tools/jasperreport/JasperReportCompiler.java
@@ -31,7 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-public class JasperReportCompiler {
+class JasperReportCompiler {
     private static final Logger LOGGER = LoggerFactory.getLogger(JasperReportCompiler.class);
     
     static final String ERROR_JRE_COMPILE_ERROR =

--- a/src/test/java/com/pro_crafting/tools/jasperreport/JasperMojoIT.java
+++ b/src/test/java/com/pro_crafting/tools/jasperreport/JasperMojoIT.java
@@ -12,9 +12,6 @@ import java.io.File;
 class JasperMojoIT {
     /**
      * Test that configuration set within a pom are correctly mapped to @{@link JasperMojoConfiguration}
-     *
-     * @throws Exception
-     *             When an unexpexted error occures.
      */
     @MavenGoal("${project.groupId}:${project.artifactId}:${project.version}:jasper")
     @MavenTest

--- a/src/test/java/com/pro_crafting/tools/jasperreport/JasperReportCompilerTest.java
+++ b/src/test/java/com/pro_crafting/tools/jasperreport/JasperReportCompilerTest.java
@@ -36,7 +36,7 @@ class JasperReportCompilerTest {
      * Test the normal generation of Jasper reports. The files are retrieved from the official
      * jasper examples folder. No errors or warnings should occur.
      *
-     * @throws Exception When an unexpexted error occures.
+     * @throws Exception When an unexpected error occurs.
      */
     @Test
     void testValidReportGeneration() throws Exception {
@@ -94,7 +94,7 @@ class JasperReportCompilerTest {
      * Test the normal generation of Jasper reports with additional properties. The files are
      * retrieved from the official jasper examples folder. No errors or warnings should occur.
      *
-     * @throws Exception When an unexpexted error occures.
+     * @throws Exception When an unexpected error occurs.
      */
     @Test
     void testGivenAdditionalPropertiesAreSetWhenTestingValidReportGenerationAndExportToPdfExpectNoErrors()


### PR DESCRIPTION
- Updated failsafe configuration to eliminate deprecation warning.
- Moved a couple of classes to packaged protected classes to avoid Javadoc warnings
- Fixed some typos (or removed extraneous comment) in some comments